### PR TITLE
Mention AuthenticatorPro as alternative

### DIFF
--- a/modules/ROOT/pages/user.adoc
+++ b/modules/ROOT/pages/user.adoc
@@ -25,7 +25,9 @@ image:screenshots/newaccount3.png[image]
 Fedora Accounts / CentOS Accounts features the ability to configure and user two-factor
 authentication through the user of OTP tokens. by default, the system
 generates Time-based One-time Password (TOTP) tokens, which can be used
-with authentication apps such as https://freeotp.github.io/[FreeOTP].
+with authentication apps such as https://freeotp.github.io/[FreeOTP]
+(Android - Apple) or
+https://github.com/jamie-mh/AuthenticatorPro[AuthenticatorPro] (Android).
 
 To create an OTP token, go to the OTP tab in the user settings, and click the *Add OTP Token* button:
 


### PR DESCRIPTION
In the past I used to use FreeOTP because it's sponsored by RedHat, but that is seems poorly maintained and misses a lot of features.
I think AuthenticatorPro is worth to be mentioned as it is fully open source, no ads, and actively developed, but only available for Android smartphones.